### PR TITLE
Another markup fix.

### DIFF
--- a/chapters/hpmor-chapter-086.tex
+++ b/chapters/hpmor-chapter-086.tex
@@ -667,7 +667,7 @@ As Professor Quirrell slowly raised up his tea, the teacup jerked in mid-air, se
 
 If that small jerky motion advanced to a constant tremor, it would be the end of any non-wandless magic for the Defence Professor. Wandwork had no room for trembling fingers. How much that would \emph{actually} handicap Professor Quirrell, if at all, Harry couldn’t guess. The Defence Professor was certainly capable of wandless magic, yet still tended to use a wand for larger things—but for him that might only be a convenience…
 
-“Insanity,” said Professor Quirrell, as he carefully sipped from his tea—he was looking at the teacup, not at Harry, which was unusual for him—”can be a signature all its own.”
+“Insanity,” said Professor Quirrell, as he carefully sipped from his tea—he was looking at the teacup, not at Harry, which was unusual for him—“can be a signature all its own.”
 
 The Defence Professor’s small office was silent, the sound-warded room quiet in a way the Headmaster’s office never could be. Sometimes the two of them both happened to finish exhaling or inhaling at the same time; and then there was an auditory emptiness that was almost a sound in itself.
 


### PR DESCRIPTION
I missed one instance in 7d24c1f6fa4e6eab50d79dac8a1bdeaa703b8973.