### PR TITLE
Fix typo in the title

### DIFF
--- a/chapters/hpmor-chapter-034.tex
+++ b/chapters/hpmor-chapter-034.tex
@@ -1,4 +1,4 @@
-\partchapter{Coordination Problems}{III}
+\partchapter{Coordination Problems}{II}
 
 \lettrine{M}{inerva} and Dumbledore together had applied their combined talent to conjure the grand stage toward which Quirrell now slowly trudged; it was, at its core, sturdy wood, but the outer surfaces shone with glitter of marble inlaid with platinum and studded with gems of every House colour. Neither she nor the Headmaster was any Founder of Hogwarts, but the conjuration only needed to last a few hours. Minerva ordinarily enjoyed the few occasions when she had the occasion to tire herself out on large Transfigurations; she should have enjoyed the many small chances for artistry, and the illusion of opulence; but this time she had done the work with the dreadful feeling of digging her own grave.
 


### PR DESCRIPTION
According to the [original version of chapter 34](https://www.hpmor.com/chapter/34), its title should be `\partchapter{...}{II}` instead of `\partchapter{...}{III}`.